### PR TITLE
New French translation

### DIFF
--- a/fr_FR.ini
+++ b/fr_FR.ini
@@ -90,29 +90,29 @@ not_found=Utilisateur non trouvé
 not_found_desc=Aucun utilisateur n'a été trouvé avec cette adresse e-mail grâce à la fonction idoine dans leurs préférences.
 
 [reset_mfa]
-title=Disable your account MFA
-disable_mfa=Disable MFA
-description=If you are locked out of your account because your MFA device is inaccessible, or for another issue preventing you from logging in, you may enter your MFA Reset Code below.
-reset_code=Reset code
+title=Désactivez le MFA pour votre compte
+disable_mfa=Désactivez le MFA
+description=Si vous ne pouvez accéder à votre compte parce que votre appareil utilisant le MFA est inutilisable, ou si un autre problème vous empêche de vous connecter, vous pouvez entrer votre code de remise à zéro du MFA ci-dessous
+reset_code=Code de remise à zéro
 
 [invites]
 invites=Invitations
 send_invite=Envoyer une invitation
 desc=Vous pouvez donner des liens vers des codes d'invitation directement, ou utiliser le champ ci-dessous pour envoyer un e-mail de notre part. <a href="/docs/resources/sign-up">Renseignez-vous</a> sur le fonctionnement des invitations.
-desc_gift_invites=Invites with a <img src="/static/images/peanuts.png" height="14"/> next to them will also <a href="/account/badge">gift a badge</a>!
-get_invite=Grab an Invite
+desc_gift_invites=Les invitations avec un <img src="/static/images/peanuts.png" height="14"/> permettent également <a href="/account/badge">d'offrir un badge</a> !
+get_invite=Récupérez une invitation
 save_notes=Sauvegarder les notes
 reserved_invite=réservé pour %s
 no_invites=Vous n'avez pas d'invitations utilisables.
 invitation_map=Plan des invitations
-look_used_invites=Look at your used invites
+look_used_invites=Les invitations que vous avez utilisé
 give_to_friend=Donnez cette invitation à un ami !
 
 [invitation_map]
-newest_users=Newest users
+newest_users=Nouveaux utilisateurs
 
 [used_invites]
-title=Used Invites
+title=Invitations utilisées
 
 [login]
 login=Se connecter
@@ -136,9 +136,9 @@ unblock=Débloquer
 
 [profile]
 pnut_subscription_expired=Votre inscription à pnut a <span class="text-warning">expiré</span> %1$s ! Mettez à jour vos réglements dans la <a href="/account/support">page Support</a> avant que votre compte ne soit limité !
-get_an_app=3rd-party developers make awesome apps for pnut. To send messages and explore the network, <a href="/apps">get an app!</a>
+get_an_app=Les développeurs tiers créent des apps formidables pour pnut ! Pour envoyer des messages et explorer le réseau, <a href="/apps">utilisez une app !</a>
 profile=Profil
-client_suggestion=You may edit your avatar and cover image from a client, such as <a href="%s">Beta</a>.
+client_suggestion=Vous pouvez modifier votre avatar et bannière à partir d'une app, telle que <a href="%s">Beta</a>.
 public_profile=Profil public
 rss_desc=Vous pouvez utiliser RSS pour lire votre flux utilisateur. Gérez vos préférences de flux ci-dessous.
 rss_badge=Le flux utilisateur RSS est une fonctionnalité réservée aux membres ! <a href="/account/support">Achetez un badge pnut</a> pour soutenir pnut.io.
@@ -156,18 +156,18 @@ on_invite_used=Nouvelle invitation utilisée
 on_major_update=Mises à jour majeures de Pnut.io
 on_mention=Mentions (à quelques minutes d'intervalle)
 on_copy_mention=Mentions cc
-email_on_chat=Chat Rooms
-email_on_poll_close=When a poll you participated in closes
+email_on_chat=Espaces de discussion
+email_on_poll_close=Quand un vote auquel vous avez participé se termine
 email_badge=Être membre vous permet d'obtenir des e-mails de notification pour les suivis et les repost ! <a href="/account/support">Achetez un badge pnut</a> pour soutenir pnut.io.
 
-advanced_options=Advanced Options
-advanced_desc=If the client you're using has a custom endpoint, you may specify the URLs that your notification E-mails will link to, below.
-advanced_instructions=Write a link, with the text <code>{id}</code> where the Post's ID or Channel's ID should be inserted.
-presets=Presets
-or_custom=or custom
-no_change=no change
-for_posts=For posts
-for_private_messages=For Private Messages
+advanced_options=Options avancées
+advanced_desc=Si l'app que vous utilisez a un point de terminaison personnalisé, vous pouvez spécifier les URL vers lesquelles vos notifications d'e-mails pointent, ci-dessous
+advanced_instructions=Entrez un lien, avec le texte <code>{id}</code> où l'ID du message ou l'ID du canal devraient être insérés.
+presets=Préréglages
+or_custom=ou personnalisé
+no_change=pas de changement
+for_posts=Pour les messages
+for_private_messages=Pour les messages privés
 
 [rss]
 manage_your_feed=Gérer votre flux
@@ -192,8 +192,8 @@ otp_desc=L'utilité des mots de passe à usage unique est de pouvoir vous identi
 otp_notice=Vous ne verrez le mot de passe qu'une fois, lors de sa création.
 new_code=Votre nouveau mot de passe à usage unique %1$s est %2$s. Veuillez <strong>utiliser ce mot de passe maintenant</strong>, car vous ne pourrez plus le consulter plus tard.
 otp_create_new=Créer nouveau mot de passe
-require_otp=Require OTP for Password Flow [CHANGE]
-require_otp_desc=If enabled, you will be required to use a One-Time Password instead of your regular password whenever logging into an app with your username and password. [CHANGE]
+require_otp=Demandez un mot de passe à usage unique pour `Password Flow`
+require_otp_desc=Si activé, vous devrez utiliser un mot de passe à usage unique au lieu de votre mot de passe habituel à chaque fois que vous vous connecterez via une app avec votre nom d'utilisateur et mot de passe
 unused_passwords=Les mots de passe suivants n'ont pas encore été utilisés :
 mfa=Authentification multi-facteurs (MFA)
 mfa_enabled_desc=Vouz devrez vérifier votre identité avec un nouveau mot de passe TOTP à chaque fois que vous vous connecterez sur le site pnut.io.
@@ -220,18 +220,18 @@ no_ip_addresses=Pas d'adresse IP connue.
 
 [badge]
 thanks_desc=Merci pour votre participation à la communauté pnut. <a href="/stats">Ces récentes statistiques</a> vous indiquent en partie ce qui s'est passé récemment.
-yes_thanks=As thanks, you have a few additional features:
-no_thanks=These are a few additional features you would have with a badge:
+yes_thanks=Pour vous remercier, vous bénéficiez de fonctionnalités supplémentaires :
+no_thanks=Voici les quelques fonctionnalités supplémentaires dont vous bénéficieriez avec un badge :
 storage=%d de stockage
 personal_stream=RSS de votre flux personnel
 notifications=Notifications par e-mail pour les reposts et nouveaux suivis
 badges=Badges
 show_badge=Montrer le badge sur votre profil
-show_badge_desc=Some apps can show a badge on your profile.
+show_badge_desc=Certaines apps peuvent montrer le badge sur votre profil.
 
 [store]
-store=Store
-not_a_member=You don't currently have a badge.
+store=Boutique
+not_a_member=vous n'avez actuellement pas de badge.
 member_status=Membre : jusqu'à %s
 current_contribution=Contribution actuelle : %s
 monthly=mensuellement
@@ -239,8 +239,8 @@ yearly=annuellement
 update_contribution=Mettre à jour votre contribution
 cancel_subscription=Annuler l'abonnement
 make_contribution=Faire un contribution
-gifting=<a href="/account/support/gift">Buy a gift badge for a friend!</a> It can be used just like any other invite, or added to an existing user's account.
-gifts=Gifts
+gifting=<a href="/account/support/gift">Offrez un badge à un ami !</a> Ce badge peut être utilisé comme toute autre invitation, ou ajouté à un compte utilisateur existant.
+gifts=Cadeaux
 
 [stats]
 recent_statistics=Statistiques récentes
@@ -313,6 +313,6 @@ user_casing_changed=Casse du nom d'utilisateur changée vers %s.
 username_invalid=Nom d'utilisateur invalide.
 warn_user_casing=Lors du changement de la casse du nom d'utilisateur, les caractères doivent rester identiques, mais peuvent être en majuscules ou minuscules.
 domain_verified=Domaine vérifié.
-domain_not_verified=Domain non vérifié.
+domain_not_verified=Domaine non vérifié.
 confirmed_delete_request=La demande de suppression de votre compte a été confirmée. Vous pouvez demander des précisions au Support à propos de cette action.
 updated_messaging=Confidentialité des messages mise à jour.

--- a/fr_FR.ini
+++ b/fr_FR.ini
@@ -16,7 +16,7 @@ search=Recherche
 your_badge=Votre badge
 buy_badge=Acheter un badge
 account_menu=Menu du compte
-username=Username
+username=Nom d'utilisateur
 password=Mot de passe
 
 [form]
@@ -159,18 +159,18 @@ on_copy_mention=Mentions cc
 email_on_chat=Espaces de discussion
 email_on_poll_close=Quand un vote auquel vous avez participé se termine
 
-email_digest=E-mail Digest
-email_digest_desc=You can receive a daily or weekly digest E-mail notifying you of any occurrences of events you have set up to watch for.
-send_email_digests=Send E-mail digests
-days_between_digests=Days between digests:
-next_digest=Next digest is expected:
-posts_from_followers=Posts from Followers:
-posts_followers_infrequent=Who haven't been posting recently
-posts_followers_trending=Trending "thread starters"
-tags=Tags:
-mentioned_users=Mentioned Users:
-channels=Channels:
-channels_active=Active channels you're subscribed to
+email_digest=Résumé des e-mails
+email_digest_desc=Vous pouvez recevoir un résumé des e-mails quotidien ou hebdomadaire pour être notifié des événements que vous qvez décidé de suivre.
+send_email_digests=Envoyer résumés des e-mails
+days_between_digests=Jours entre chaque résumé :
+next_digest=Le prochain résumé est attendu pour le :
+posts_from_followers=Posts des utilisateurs qui vous suivent :
+posts_followers_infrequent=Qui n'ont pas posté récemment
+posts_followers_trending=Initiateurs de discussions
+tags=Tags :
+mentioned_users=Utilisateurs mentionnés :
+channels=Channels :
+channels_active=Channels actives auxquelles vous êtes abonné
 
 advanced_options=Options avancées
 advanced_desc=Si l'app que vous utilisez a un point de terminaison personnalisé, vous pouvez spécifier les URL vers lesquelles vos notifications d'e-mails pointent, ci-dessous


### PR DESCRIPTION
The new items have been translated. 

Note that I chose to keep "channels" as is because there's no real equivalent in French, and we're used to use such English terms instead anyway. Same with "posts" and "e-mail".